### PR TITLE
Set correct Apache License in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/ryanelian/ts-polyfill/issues",
     "email": "ryan.elian@accelist.com"
   },
-  "license": "Unlicense",
+  "license": "Apache-2.0",
   "author": {
     "name": "Ryan Elian",
     "email": "ryan.elian@accelist.com",


### PR DESCRIPTION
Since you have the Apache 2.0 License checked in I thought I add it to the package json as well. That makes it easier for users to figure out if there are legal issues in their project.